### PR TITLE
Fixed password icon issue and forgot password page

### DIFF
--- a/lib/feature/auth/widget/forgot_password_page.dart
+++ b/lib/feature/auth/widget/forgot_password_page.dart
@@ -3,13 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_boilerplate/feature/auth/model/auth_state.dart';
 import 'package:flutter_boilerplate/feature/auth/provider/auth_provider.dart';
 import 'package:flutter_boilerplate/shared/route/router.gr.dart';
+import 'package:flutter_boilerplate/shared/util/validator.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../../../shared/constants/app_theme.dart';
 
 class ForgotPasswordPage extends ConsumerWidget {
-  final _passwordController = TextEditingController();
-  final passwordLoginVisibilityProvider = StateProvider<bool>((ref) => false);
+  final _emailController = TextEditingController();
 
   ForgotPasswordPage({Key? key}) : super(key: key);
 
@@ -18,7 +18,6 @@ class ForgotPasswordPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    bool passwordLoginVisibility = ref.watch(passwordLoginVisibilityProvider);
     ref.listen(authProvider, (previous, next) {
       if (next is AuthState) {
         next.maybeWhen(
@@ -46,38 +45,48 @@ class ForgotPasswordPage extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
+                Text(
+                  'Reset Password',
+                  style:
+                      GoogleFonts.getFont('Montserrat', textStyle: loginTitle),
+                ),
                 Padding(
-                  padding: const EdgeInsetsDirectional.fromSTEB(0, 200, 0, 10),
-                  child: Text(
-                    'Reset Password',
-                    style: GoogleFonts.getFont('Montserrat',
-                        textStyle: loginTitle),
+                  padding: const EdgeInsetsDirectional.fromSTEB(0, 12, 0, 0),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.max,
+                    children: [
+                      Text(
+                        'Please insert the email associated with your\naccount to receive a password reset link!',
+                        style: GoogleFonts.getFont('Montserrat',
+                            textStyle: loginSecondaryTitle),
+                      ),
+                    ],
                   ),
                 ),
                 Form(
                   key: _formKey,
                   child: Column(
                     children: [
-                      //password input field
+                      //email input field
                       Padding(
                         padding:
-                            const EdgeInsetsDirectional.fromSTEB(0, 12, 0, 0),
+                            const EdgeInsetsDirectional.fromSTEB(0, 15, 0, 0),
                         child: TextFormField(
-                          controller: _passwordController,
-                          obscureText: passwordLoginVisibility,
+                          controller: _emailController,
+                          obscureText: false,
                           decoration: InputDecoration(
-                            labelText: 'Password',
+                            labelText: 'Email Address',
                             labelStyle: GoogleFonts.getFont(
                               'Montserrat',
                               textStyle: loginEmailText,
                             ),
-                            hintText: 'Enter your password...',
+                            hintText: 'Enter your email...',
                             hintStyle: GoogleFonts.getFont(
                               'Montserrat',
                               textStyle: loginEmailText,
                             ),
                             enabledBorder: OutlineInputBorder(
-                              borderSide: const BorderSide(
+                              borderSide: BorderSide(
                                 color: primaryColor,
                                 width: 1,
                               ),
@@ -109,26 +118,14 @@ class ForgotPasswordPage extends ConsumerWidget {
                             contentPadding:
                                 const EdgeInsetsDirectional.fromSTEB(
                                     20, 24, 20, 24),
-                            suffixIcon: InkWell(
-                              onTap: () => ref
-                                  .read(
-                                    passwordLoginVisibilityProvider.state,
-                                  )
-                                  .state = false,
-                              focusNode: FocusNode(skipTraversal: true),
-                              child: Icon(
-                                passwordLoginVisibility
-                                    ? Icons.visibility_outlined
-                                    : Icons.visibility_off_outlined,
-                                color: Colors.black,
-                                size: 20,
-                              ),
-                            ),
                           ),
-                          style: GoogleFonts.getFont('Montserrat'),
+                          style: GoogleFonts.getFont(
+                            'Montserrat',
+                          ),
                           validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Enter Password';
+                            Validator.isValidEmail(value);
+                            if (Validator.isValidEmail(value) == false) {
+                              return 'Please enter a valid email!';
                             }
 
                             return null;
@@ -164,7 +161,7 @@ class ForgotPasswordPage extends ConsumerWidget {
       child: TextButton(
         onPressed: () {},
         child: Text(
-          'Reset Password',
+          'Send Reset Password Link',
           style: GoogleFonts.getFont('Montserrat', textStyle: loginButtonText),
         ),
       ),

--- a/lib/feature/auth/widget/sign_in_page.dart
+++ b/lib/feature/auth/widget/sign_in_page.dart
@@ -245,9 +245,9 @@ class SignInPage extends ConsumerWidget {
                                                 onTap: () => ref
                                                     .read(
                                                       passwordLoginVisibilityProvider
-                                                          .state,
+                                                          .notifier,
                                                     )
-                                                    .state = false,
+                                                    .state = !passwordLoginVisibility,
                                                 focusNode: FocusNode(
                                                     skipTraversal: true),
                                                 child: Icon(

--- a/lib/feature/auth/widget/sign_up_page.dart
+++ b/lib/feature/auth/widget/sign_up_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_boilerplate/feature/auth/model/auth_state.dart';
 import 'package:flutter_boilerplate/feature/auth/provider/auth_provider.dart';
+import 'package:flutter_boilerplate/shared/route/router.gr.dart';
 import 'package:flutter_boilerplate/shared/util/validator.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -12,14 +13,20 @@ class SignUpPage extends ConsumerWidget {
   final _nameController = TextEditingController();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  final passwordLoginVisibilityProvider = StateProvider<bool>((ref) => true);
 
   //form key validation
   final _formKey = GlobalKey<FormState>();
+
+  void togglePasswordView(Widget ref) {
+    
+  }
 
   SignUpPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    bool passwordLoginVisibility = ref.watch(passwordLoginVisibilityProvider);
     var mediaHeight = MediaQuery.of(context).size * 1;
     var mediaWidth = MediaQuery.of(context).size * 1;
     ref.listen(authProvider, (previous, next) {
@@ -208,14 +215,18 @@ class SignUpPage extends ConsumerWidget {
                             const EdgeInsetsDirectional.fromSTEB(0, 20, 0, 0),
                         child: TextFormField(
                           controller: _passwordController,
-                          obscureText: false,
+                          obscureText: passwordLoginVisibility,
                           decoration: InputDecoration(
                             labelText: 'Password',
-                            labelStyle: GoogleFonts.getFont('Montserrat',
-                                textStyle: loginEmailText),
-                            hintText: 'Enter password...',
-                            hintStyle: GoogleFonts.getFont('Montserrat',
-                                textStyle: loginEmailText),
+                            labelStyle: GoogleFonts.getFont(
+                              'Montserrat',
+                              textStyle: loginEmailText,
+                            ),
+                            hintText: 'Enter your password...',
+                            hintStyle: GoogleFonts.getFont(
+                              'Montserrat',
+                              textStyle: loginEmailText,
+                            ),
                             enabledBorder: OutlineInputBorder(
                               borderSide: const BorderSide(
                                 color: primaryColor,
@@ -249,6 +260,21 @@ class SignUpPage extends ConsumerWidget {
                             contentPadding:
                                 const EdgeInsetsDirectional.fromSTEB(
                                     20, 24, 20, 24),
+                            suffixIcon: InkWell(
+                              onTap: () => ref
+                                  .read(
+                                    passwordLoginVisibilityProvider.notifier,
+                                  )
+                                  .state = !passwordLoginVisibility,
+                              focusNode: FocusNode(skipTraversal: true),
+                              child: Icon(
+                                passwordLoginVisibility
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                                color: Colors.black,
+                                size: 20,
+                              ),
+                            ),
                           ),
                           style: GoogleFonts.getFont('Montserrat'),
                           validator: (value) {
@@ -326,6 +352,7 @@ class SignUpPage extends ConsumerWidget {
                   _emailController.text,
                   _passwordController.text,
                 );
+            context.router.push(SignInRoute());
           }
         },
         child: Text(


### PR DESCRIPTION
## Description

Fixed password icon not changing obscure text from true to false back to true. Now it will change based on icon tap. Also refactored Forgot Password page for an email input to eventually add email password reset.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ `x`] 🗑️ Chore
